### PR TITLE
Moved SPI.begin() after reset

### DIFF
--- a/src/utility/spi_drv.cpp
+++ b/src/utility/spi_drv.cpp
@@ -90,7 +90,6 @@ void SpiDrv::begin()
       }      
 #endif
 
-      SPIWIFI.begin();
       pinMode(SLAVESELECT, OUTPUT);
       pinMode(SLAVEREADY, INPUT);
       pinMode(SLAVERESET, OUTPUT);
@@ -105,6 +104,8 @@ void SpiDrv::begin()
 
       digitalWrite(NINA_GPIO0, LOW);
       pinMode(NINA_GPIO0, INPUT);
+
+      SPIWIFI.begin();
 
 #ifdef _DEBUG_
 	  INIT_TRIGGER()


### PR DESCRIPTION
GPIO12 (used as MOSI) is a bootstrap pin. If it is driven low at the startup the flash is driven at 1.8V instead that 3.3V causing the ESP32 to reset continuosly.