### PR TITLE
Speed up resolving bad host names

### DIFF
--- a/src/utility/wifi_drv.cpp
+++ b/src/utility/wifi_drv.cpp
@@ -719,6 +719,10 @@ uint8_t WiFiDrv::reqHostByName(const char* aHostname)
 
     SpiDrv::spiSlaveDeselect();
 
+    if (result) {
+        result = (_data == 1);
+    }
+
     return result;
 }
 

--- a/src/utility/wifi_drv.cpp
+++ b/src/utility/wifi_drv.cpp
@@ -752,17 +752,12 @@ int WiFiDrv::getHostByName(IPAddress& aResult)
 
 int WiFiDrv::getHostByName(const char* aHostname, IPAddress& aResult)
 {
-	uint8_t retry = 10;
 	if (reqHostByName(aHostname))
 	{
-		while(!getHostByName(aResult) && --retry > 0)
-		{
-			delay(1000);
-		}
+		return getHostByName(aResult);
 	}else{
 		return 0;
 	}
-	return (retry>0);
 }
 
 const char*  WiFiDrv::getFwVersion()


### PR DESCRIPTION
Related to #18.

Two changes:

1) If the result of `REQ_HOST_BY_NAME_CMD` comes through the data value contains the result of the DNS lookup (1 for success, and 0 for failure), use this in the return code.

2) Removed the unnecessary retry for the `GET_HOST_BY_NAME_CMD` command. If it returns 0xffffffff, then the DNS lookup failed. No need to retry.