### PR TITLE
Increase poll time of checking connection status to 100ms on begin, also adjust retry count accordingly

### DIFF
--- a/src/utility/wifi_drv.h
+++ b/src/utility/wifi_drv.h
@@ -29,8 +29,8 @@
 
 // Key index length
 #define KEY_IDX_LEN     1
-// 5 secs of delay to have the connection established
-#define WL_DELAY_START_CONNECTION 5000
+// 100 msecs of delay to have the connection established
+#define WL_DELAY_START_CONNECTION 100
 // firmware version string length
 #define WL_FW_VER_LENGTH 6
 

--- a/src/utility/wl_definitions.h
+++ b/src/utility/wl_definitions.h
@@ -46,7 +46,7 @@
 // Default state value for Wifi state field
 #define NA_STATE -1
 //Maximum number of attempts to establish wifi connection
-#define WL_MAX_ATTEMPT_CONNECTION	10
+#define WL_MAX_ATTEMPT_CONNECTION	500
 
 typedef enum {
 	WL_NO_SHIELD = 255,


### PR DESCRIPTION
As suggested by @ilcato.

When used in conjunction with https://github.com/arduino/nina-fw/pull/9, I can connect to my AP in ~4.2 to ~4.7 seconds.