### PR TITLE
WiFiServer: check previous received client socket for data before querying a new one

### DIFF
--- a/src/WiFiServer.cpp
+++ b/src/WiFiServer.cpp
@@ -30,7 +30,8 @@ extern "C" {
 #include "WiFiServer.h"
 
 WiFiServer::WiFiServer(uint16_t port) :
-  _sock(NO_SOCKET_AVAIL)
+  _sock(NO_SOCKET_AVAIL),
+  _lastSock(NO_SOCKET_AVAIL)
 {
     _port = port;
 }
@@ -49,7 +50,19 @@ WiFiClient WiFiServer::available(byte* status)
     int sock = NO_SOCKET_AVAIL;
 
     if (_sock != NO_SOCKET_AVAIL) {
-        sock = ServerDrv::availServer(_sock);
+      // check previous received client socket
+      if (_lastSock != NO_SOCKET_AVAIL) {
+          WiFiClient client(_lastSock);
+
+          if (client.connected() && client.available()) {
+              sock = _lastSock;
+          }
+      }
+
+      if (sock == NO_SOCKET_AVAIL) {
+          // check for new client socket
+          sock = ServerDrv::availServer(_sock);
+      }
     }
 
     if (sock != NO_SOCKET_AVAIL) {
@@ -58,6 +71,8 @@ WiFiClient WiFiServer::available(byte* status)
         if (status != NULL) {
             *status = client.status();
         }
+
+        _lastSock = sock;
 
         return client;
     }

--- a/src/WiFiServer.h
+++ b/src/WiFiServer.h
@@ -32,6 +32,7 @@ class WiFiClient;
 class WiFiServer : public Server {
 private:
   uint8_t _sock;
+  uint8_t _lastSock;
   uint16_t _port;
   void*     pcb;
 public:


### PR DESCRIPTION
Resolves #52.