### PR TITLE
Set correct firmware version value for MKR Vidor 4000

### DIFF
--- a/src/WiFi.h
+++ b/src/WiFi.h
@@ -21,7 +21,11 @@
 #ifndef WiFi_h
 #define WiFi_h
 
+#if defined(ARDUINO_SAMD_MKRVIDOR4000)
+#define WIFI_FIRMWARE_LATEST_VERSION "1.1.0"
+#else
 #define WIFI_FIRMWARE_LATEST_VERSION "1.2.1"
+#endif
 
 #include <inttypes.h>
 


### PR DESCRIPTION
Although the newest available WiFiNINA firmware version shipped with Arduino IDE 1.8.9 is 1.2.1, that firmware version is only available for MKR WiFi 1010 and Uno WiFi Rev2. The newest WiFiNINA firmware version available for the MKR Vidor 4000 is 1.1.0. Previously, the value of `WIFI_FIRMWARE_LATEST_VERSION` was set to 1.2.1 for all boards, which resulted in spurious warnings from the CheckFirmware sketch, as well as all the WiFiNINA library examples:
```
WiFiNINA firmware check.

Firmware version installed: 1.1.0
Latest firmware version available : 1.2.1

Check result: NOT PASSED
 - The firmware version on the module do not match the
   version required by the library, you may experience
   issues or failures.
```

Fixes https://github.com/arduino-libraries/WiFiNINA/issues/68

Originally reported at:
https://forum.arduino.cc/index.php?topic=623374.new#new