### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=WiFiNINA
-version=1.4.0
+version=1.5.0
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables network connection (local and Internet) with the Arduino MKR WiFi 1010, Arduino MKR VIDOR 4000, Arduino UNO WiFi Rev.2 and Nano 33 IoT.

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,5 @@ paragraph=With this library you can instantiate Servers, Clients and send/receiv
 category=Communication
 url=http://www.arduino.cc/en/Reference/WiFiNINA
 architectures=*
+depends=VidorPeripherals
 includes=WiFiNINA.h


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes Library Manager to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format