### PR TITLE
Don't change default baud rate for MKR Vidor 4000

### DIFF
--- a/examples/Tools/SerialNINAPassthrough/SerialNINAPassthrough.ino
+++ b/examples/Tools/SerialNINAPassthrough/SerialNINAPassthrough.ino
@@ -21,11 +21,9 @@
 
 #ifdef ARDUINO_SAMD_MKRVIDOR4000
 #include <VidorPeripherals.h>
-
-unsigned long baud = 119400;
-#else
-unsigned long baud = 115200;
 #endif
+
+unsigned long baud = 115200;
 
 int rts = -1;
 int dtr = -1;


### PR DESCRIPTION
The esptool expects an initial detection phase where baud rate is 115200. Setting it to 119400 is causing wacky warnings like detecting an incorrect crystal frequency:
```
WARNING: Detected crystal freq 38.94MHz is quite different to normalized freq 40MHz. Unsupported crystal in use?
Crystal is 40MHz
```
It still works fine with 119400 rate, but it creates a warning and there's no need to distinguish Vidor from the other MKR boards here.