### PR TITLE
Allow NINA baud rate change on MKR Vidor 4000

### DIFF
--- a/examples/Tools/SerialNINAPassthrough/SerialNINAPassthrough.ino
+++ b/examples/Tools/SerialNINAPassthrough/SerialNINAPassthrough.ino
@@ -97,9 +97,7 @@ void loop() {
     dtr = -1;
 
     baud = Serial.baud();
-#ifndef ARDUINO_SAMD_MKRVIDOR4000
     SerialNina.begin(baud);
-#endif
   }
 #endif
 }


### PR DESCRIPTION
The gating that disables SerialNina rate change on the MKR Vidor 4000 is not needed.

You CAN change the rate, I have successfully flashed with 460800:
```
python /opt/esp-idf/components/esptool_py/esptool/esptool.py --no-stub --chip esp32 --port /dev/ttyACM0 --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect 0x0 WiFi101-FirmwareUpdater-Plugin/firmwares/NINA/1.2.1/NINA_W102.bin
esptool.py v2.8
Serial port /dev/ttyACM0
Connecting....
Chip is ESP32D0WDQ6 (revision 1)
Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 80:7d:3a:86:7f:78
Changing baud rate to 460800
Changed.
Auto-detected Flash size: 2MB
Erasing flash...
Compressed 880640 bytes to 495730...
Took 7.62s to erase flash block
Wrote 880640 bytes (495730 compressed) at 0x00000000 in 776.3 seconds (effective 9.1 kbit/s)...
```

And confirmed with CheckFirmwareVersion:
```
WiFiNINA firmware check.

Firmware version installed: 1.2.1
Latest firmware version available : 1.2.1

Check result: PASSED
```

921600 did not work however.