### PR TITLE
Give SerialNINAPassthrough flash rate 10x speedup

### DIFF
--- a/examples/Tools/SerialNINAPassthrough/SerialNINAPassthrough.ino
+++ b/examples/Tools/SerialNINAPassthrough/SerialNINAPassthrough.ino
@@ -27,6 +27,10 @@ unsigned long baud = 119400;
 unsigned long baud = 115200;
 #endif
 
+#define BUFFER_SIZE 512
+static unsigned int buffer_length;
+static char buffer[BUFFER_SIZE];
+
 int rts = -1;
 int dtr = -1;
 
@@ -82,12 +86,16 @@ void loop() {
   }
 #endif
 
-  if (Serial.available()) {
-    SerialNina.write(Serial.read());
+  if (Serial.available() > 0) {
+    buffer_length = min(Serial.available(), BUFFER_SIZE);
+    Serial.readBytes(buffer, buffer_length);
+    SerialNina.write(buffer, buffer_length);
   }
 
-  if (SerialNina.available()) {
-    Serial.write(SerialNina.read());
+  if (SerialNina.available() > 0) {
+    buffer_length = min(SerialNina.available(), BUFFER_SIZE);
+    SerialNina.readBytes(buffer, buffer_length);
+    Serial.write(buffer, buffer_length);
   }
 
 #ifndef ARDUINO_AVR_UNO_WIFI_REV2


### PR DESCRIPTION
Buffering the Serial TX/RX makes flashing with esptool that much faster.
Instead of 13.5 minutes it now takes a mere 47.9 seconds on MKR Vidor 4000.

I tested flashing with a couple buffer sizes: 16, 64, 4096, 512, 128 and settled on 512 which gave the highest transfer rate:
```
> python /opt/esp-idf/components/esptool_py/esptool/esptool.py --no-stub --chip esp32 --port /dev/ttyACM0 --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect 0x0 WiFi101-FirmwareUpdater-Plugin/firmwares/NINA/1.2.1/NINA_W102.bin
esptool.py v2.8
Serial port /dev/ttyACM0
Connecting....
Chip is ESP32D0WDQ6 (revision 1)
Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 80:7d:3a:86:7f:78
Changing baud rate to 460800
Changed.
Enabling default SPI flash mode...
Configuring flash size...
Auto-detected Flash size: 2MB
Erasing flash...
Compressed 880640 bytes to 495730...
Took 7.31s to erase flash block
Wrote 880640 bytes (495730 compressed) at 0x00000000 in 47.9 seconds (effective 147.0 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
```