### PR TITLE
Limit the maximum length of the download URL for the OTA binary to 128 bytes

### DIFF
--- a/src/WiFiStorage.h
+++ b/src/WiFiStorage.h
@@ -59,6 +59,13 @@ public:
 		return true;
 	}
     static bool downloadOTA(const char * url, uint8_t * res_ota_download = NULL) {
+		/* The buffer within the nina firmware allows a maximum
+		 * url size of 128 bytes. It's better to prevent the
+		 * transmission of over-sized URL as soon as possible.
+		 */
+		if (strlen(url) > 128)
+			return false;
+
 		uint8_t const res = WiFiDrv::downloadOTA(url, strlen(url));
 		if (res_ota_download)
 		  *res_ota_download = res;


### PR DESCRIPTION
Reason: The receive buffer on the nina firmware can't hold more than [128 bytes](https://github.com/arduino/nina-fw/blob/master/main/CommandHandler.cpp#L1404).
CC @eclipse1985 @luigigubello 