### PR TITLE
Add possibility to resend data if lwip_send fails

### DIFF
--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -207,19 +207,29 @@ size_t WiFiClient::write(const uint8_t *buf, size_t size) {
   if (size==0)
   {
 	  setWriteError();
-      return 0;
+    return 0;
   }
 
-  size_t written = ServerDrv::sendData(_sock, buf, size);
-  if (!written)
-  {
-	  setWriteError();
-      return 0;
+  bool success = false;
+  size_t written = 0;
+  for (int i=0; i<5; i++) {
+    written = ServerDrv::sendData(_sock, buf, size);
+    if (written) {
+      success = true;
+      break;
+    }
   }
-  if (!ServerDrv::checkDataSent(_sock))
-  {
-	  setWriteError();
-      return 0;
+  if (success) {
+    if (!ServerDrv::checkDataSent(_sock))
+    {
+      setWriteError();
+        return 0;
+    }
+  } else {
+    // close socket
+    ServerDrv::stopClient(_sock);
+    setWriteError();
+    return 0;
   }
 
   return written;

--- a/src/WiFiClient.h
+++ b/src/WiFiClient.h
@@ -40,10 +40,12 @@ public:
   virtual int connectBearSSL(const char *host, uint16_t port);
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);
+  virtual size_t retry(const uint8_t *buf, size_t size, bool write);
   virtual int available();
   virtual int read();
   virtual int read(uint8_t *buf, size_t size);
   virtual int peek();
+  virtual void setRetry(bool retry);
   virtual void flush();
   virtual void stop();
   virtual uint8_t connected();
@@ -61,6 +63,7 @@ private:
   static uint16_t _srcport;
   uint8_t _sock;   //not used
   uint16_t  _socket;
+  bool _retrySend;
 };
 
 #endif


### PR DESCRIPTION
This PR, together with [nina-fw PR #62](https://github.com/arduino/nina-fw/pull/62), would solve issue [#61](https://github.com/arduino/nina-fw/issues/61) of nina-fw. 
In the previous implementation, as soon as a write failed, the socket was closed and the connection dropped. Failures happen especially when large files are sent (100k-1M characters). 
The provided modifications avoid to immediately drop the connection. The same packet can be sent up to 5 times. Only after 5 consecutive failures the socket will be closed.
The retry will be enabled by default. However, if the user doesn't want to enable it and close the communication at the first failure (previous behavior), he/she can disable it with `setRetry(false)`.

The new function `retry(const uint8_t *buf, size_t size, bool write)` is currently implemented to be used only for a write operation. However, the last parameter `bool write` has been inserted to allow the implementation in the future of the same logic for a read operation, if needed.