### PR TITLE
Added non-blocking connect method

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -61,6 +61,14 @@ int WiFiClass::begin(const char* ssid)
    return status;
 }
 
+int WiFiClass::connect(const char* ssid) {
+    uint8_t status = WL_CONNECT_FAILED;
+    if (WiFiDrv::wifiSetNetwork(ssid, strlen(ssid)) != WL_FAILURE) {
+	    status = WiFiDrv::getConnectionStatus();
+    }
+    return status;
+}
+
 int WiFiClass::begin(const char* ssid, uint8_t key_idx, const char *key)
 {
 	uint8_t status = WL_IDLE_STATUS;
@@ -80,6 +88,15 @@ int WiFiClass::begin(const char* ssid, uint8_t key_idx, const char *key)
    return status;
 }
 
+int WiFiClass::connect(const char* ssid, uint8_t key_idx, const char *key) {
+    uint8_t status = WL_CONNECT_FAILED;
+    if (WiFiDrv::wifiSetKey(ssid, strlen(ssid), key_idx, key, strlen(key)) != WL_FAILURE) {
+        delay(WL_DELAY_START_CONNECTION);
+        status = WiFiDrv::getConnectionStatus();
+    }
+    return status;
+}
+
 int WiFiClass::begin(const char* ssid, const char *passphrase)
 {
 	uint8_t status = WL_IDLE_STATUS;
@@ -96,6 +113,15 @@ int WiFiClass::begin(const char* ssid, const char *passphrase)
 	   while ((( status == WL_IDLE_STATUS)||(status == WL_NO_SSID_AVAIL)||(status == WL_SCAN_COMPLETED))&&(--attempts>0));
     }else{
     	status = WL_CONNECT_FAILED;
+    }
+    return status;
+}
+
+int WiFiClass::connect(const char* ssid, const char *passphrase) {
+    uint8_t status = WL_CONNECT_FAILED;
+    if (WiFiDrv::wifiSetPassphrase(ssid, strlen(ssid), passphrase, strlen(passphrase))!= WL_FAILURE) {
+        delay(WL_DELAY_START_CONNECTION);
+        status = WiFiDrv::getConnectionStatus();
     }
     return status;
 }

--- a/src/WiFi.h
+++ b/src/WiFi.h
@@ -74,6 +74,10 @@ public:
      */
     int begin(const char* ssid, const char *passphrase);
 
+    int connect(const char* ssid);
+    int connect(const char* ssid, uint8_t key_idx, const char* key);
+    int connect(const char* ssid, const char *passphrase);
+
     uint8_t beginAP(const char *ssid);
     uint8_t beginAP(const char *ssid, uint8_t channel);
     uint8_t beginAP(const char *ssid, const char* passphrase);


### PR DESCRIPTION
This is not completely non-blocking. Please review the delay of 100ms after setting passphrase or key of the normal "begin()" method. To resolution is a little un-optimized at the moment but I needed to to work for now:

WiFi.cpp:
>     int WiFiClass::setCredNB(const char* ssid, const char *passphrase)
>     {
>       uint8_t status = WL_CONNECT_FAILED;
>       startConnection = millis();
>       delayStartConnection = millis();
> 
>       if (WiFiDrv::wifiSetPassphrase(ssid, strlen(ssid), passphrase, strlen(passphrase))!= WL_FAILURE) {
>         status = WiFiDrv::getConnectionStatus();
>       }
> 
>       return status;
>     }
> 
>     int WiFiClass::beginNB()
>     {
>       uint8_t status = WL_CONNECT_FAILED;
> 
>       if ((millis() - startConnection) < _timeout) {
>         if ((millis() - delayStartConnection) > WL_DELAY_START_CONNECTION) {
>           status = WiFiDrv::getConnectionStatus();
>           delayStartConnection = millis();
>         }
>       }
> 
>       return status;
>     }

WiFi.h, add to public section:
>     unsigned long startConnection;
>     unsigned long delayStartConnection;
> 
>     int setCredNB(const char* ssid, const char* passphrase);
>     int beginNB();