### PR TITLE
Bugfix: The latest available wifi firmware version is in fact 1.4.1, not 1.4.2

### DIFF
--- a/src/WiFi.h
+++ b/src/WiFi.h
@@ -21,7 +21,7 @@
 #ifndef WiFi_h
 #define WiFi_h
 
-#define WIFI_FIRMWARE_LATEST_VERSION "1.4.2"
+#define WIFI_FIRMWARE_LATEST_VERSION "1.4.1"
 
 #include <inttypes.h>
 


### PR DESCRIPTION
This fixes #148.