### PR TITLE
[BUGfix]: prevent Compiler warning in WiFiClient.cpp!

### DIFF
--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -245,8 +245,9 @@ size_t WiFiClient::retry(const uint8_t *buf, size_t size, bool write) {
     return rec_bytes;
 
   } else {
-    //RETRY READ
-    // To be implemented, if needed
+	  return rec_bytes;
+      //RETRY READ
+      // To be implemented, if needed
   }
 
 }


### PR DESCRIPTION
# Prevent Comiler warning in WiFiClient.cpp

- 'no return of non-void-function'