### PR TITLE
Bugfix: Feed watchdog within busy-wait-loop within connectBearSSL to prevent a premature reset.

### DIFF
--- a/src/utility/server_drv.cpp
+++ b/src/utility/server_drv.cpp
@@ -130,7 +130,7 @@ void ServerDrv::startClient(const char* host, uint8_t host_len, uint32_t ipAddre
 
     SpiDrv::spiSlaveDeselect();
     //Wait the reply elaboration
-    SpiDrv::waitForSlaveReady();
+    SpiDrv::waitForSlaveReady(/* feed_watchdog = */ (protMode == TLS_BEARSSL_MODE));
     SpiDrv::spiSlaveSelect();
 
     // Wait for reply

--- a/src/utility/spi_drv.cpp
+++ b/src/utility/spi_drv.cpp
@@ -207,9 +207,30 @@ void SpiDrv::waitForSlaveSign()
 	while (!waitSlaveSign());
 }
 
-void SpiDrv::waitForSlaveReady()
+#if defined __has_include
+#  if __has_include (<Adafruit_SleepyDog.h>)
+#    include <Adafruit_SleepyDog.h>
+#    define HAS_WATCHDOG 1
+#  endif
+#else
+#  define HAS_WATCHDOG 0
+#endif
+
+void SpiDrv::waitForSlaveReady(bool const feed_watchdog)
 {
-	while (!waitSlaveReady());
+#if HAS_WATCHDOG
+    unsigned long const start = millis();
+#endif /* HAS_WATCHDOG */
+	while (!waitSlaveReady())
+    {
+#if HAS_WATCHDOG
+        if (feed_watchdog) {
+            if ((millis() - start) < 10000) {
+                Watchdog.reset();
+            }
+        }
+#endif /* HAS_WATCHDOG */
+    }
 }
 
 void SpiDrv::getParam(uint8_t* param)

--- a/src/utility/spi_drv.h
+++ b/src/utility/spi_drv.h
@@ -59,7 +59,7 @@ public:
     
     static char spiTransfer(volatile char data);
 
-    static void waitForSlaveReady();
+    static void waitForSlaveReady(bool const feed_watchdog = false);
 
     //static int waitSpiChar(char waitChar, char* readChar);
 


### PR DESCRIPTION
Within the Arduino IoT Cloud firmware stack we are using a watchdog to prevent unintended application lockup. Unfortunately in certain situations the connection attempt undertaken within WiFiNINA can take so long that the watchdog is triggered although everything is fine. This change is feeding the watchdog (if one is present) so to avoid prematurely triggering of the watchdog.