### PR TITLE
Allow access to RGB LED as well as A4-A7 via classic Arduino APIs

### DIFF
--- a/src/utility/nano_rp2040_support.cpp
+++ b/src/utility/nano_rp2040_support.cpp
@@ -30,43 +30,42 @@
  * FUNCTION DEFINITION
  ******************************************************************************/
 
+uint8_t toAnalogPin(NinaPin pin)
+{
+  if      (pin == A4) return 6; /* ADC1 - CH6 */
+  else if (pin == A5) return 3; /* ADC1 - CH3 */
+  else if (pin == A6) return 0; /* ADC1 - CH0 */
+  else if (pin == A7) return 7; /* ADC1 - CH7 */
+  else                return 0xFF;
+}
+
 void pinMode(NinaPin pin, PinMode mode)
 {
-  WiFiDrv::wifiDriverInit();
-  Serial.print(__FUNCTION__);
-  Serial.print(": pin = ");
-  Serial.print(pin);
-  Serial.print(", mode = ");
-  Serial.println(mode);
   WiFiDrv::pinMode(static_cast<uint8_t>(pin), static_cast<uint8_t>(mode));
 }
 
 PinStatus digitalRead(NinaPin pin)
 {
-  WiFiDrv::wifiDriverInit();
   return WiFiDrv::digitalRead(static_cast<uint8_t>(pin));
 }
 
 void digitalWrite(NinaPin pin, PinStatus value)
 {
-  WiFiDrv::wifiDriverInit();
-  Serial.print(__FUNCTION__);
-  Serial.print(": pin = ");
-  Serial.print(pin);
-  Serial.print(", value = ");
-  Serial.println(value);
   WiFiDrv::digitalWrite(static_cast<uint8_t>(pin), static_cast<uint8_t>(value));
 }
 
 int analogRead(NinaPin pin)
 {
-  WiFiDrv::wifiDriverInit();
-  return WiFiDrv::analogRead(static_cast<uint8_t>(pin));
+  uint8_t const adc_channel = toAnalogPin(pin);
+
+  if (adc_channel == 0xFF)
+    return 0;
+  else
+    return WiFiDrv::analogRead(adc_channel);
 }
 
 void analogWrite(NinaPin pin, int value)
 {
-  WiFiDrv::wifiDriverInit();
   WiFiDrv::analogWrite(static_cast<uint8_t>(pin), static_cast<uint8_t>(value));
 }
 

--- a/src/utility/nano_rp2040_support.cpp
+++ b/src/utility/nano_rp2040_support.cpp
@@ -1,0 +1,73 @@
+/*
+  This file is part of the WiFiNINA library.
+  Copyright (c) 2021 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifdef ARDUINO_NANO_RP2040_CONNECT
+
+/******************************************************************************
+ * INCLUDE
+ ******************************************************************************/
+
+#include "nina_pins.h" /* variants/NANO_RP2040_CONNECT/ninaPins.h */
+#include "wifi_drv.h"
+
+/******************************************************************************
+ * FUNCTION DEFINITION
+ ******************************************************************************/
+
+void pinMode(NinaPin pin, PinMode mode)
+{
+  WiFiDrv::wifiDriverInit();
+  Serial.print(__FUNCTION__);
+  Serial.print(": pin = ");
+  Serial.print(pin);
+  Serial.print(", mode = ");
+  Serial.println(mode);
+  WiFiDrv::pinMode(static_cast<uint8_t>(pin), static_cast<uint8_t>(mode));
+}
+
+PinStatus digitalRead(NinaPin pin)
+{
+  WiFiDrv::wifiDriverInit();
+  return WiFiDrv::digitalRead(static_cast<uint8_t>(pin));
+}
+
+void digitalWrite(NinaPin pin, PinStatus value)
+{
+  WiFiDrv::wifiDriverInit();
+  Serial.print(__FUNCTION__);
+  Serial.print(": pin = ");
+  Serial.print(pin);
+  Serial.print(", value = ");
+  Serial.println(value);
+  WiFiDrv::digitalWrite(static_cast<uint8_t>(pin), static_cast<uint8_t>(value));
+}
+
+int analogRead(NinaPin pin)
+{
+  WiFiDrv::wifiDriverInit();
+  return WiFiDrv::analogRead(static_cast<uint8_t>(pin));
+}
+
+void analogWrite(NinaPin pin, int value)
+{
+  WiFiDrv::wifiDriverInit();
+  WiFiDrv::analogWrite(static_cast<uint8_t>(pin), static_cast<uint8_t>(value));
+}
+
+#endif /* ARDUINO_NANO_RP2040_CONNECT */

--- a/src/utility/wifi_drv.cpp
+++ b/src/utility/wifi_drv.cpp
@@ -1119,12 +1119,12 @@ void WiFiDrv::digitalWrite(uint8_t pin, uint8_t value)
     SpiDrv::spiSlaveDeselect();
 }
 
-uint16_t WiFiDrv::analogRead(uint8_t pin)
+uint16_t WiFiDrv::analogRead(uint8_t adc_channel)
 {
     WAIT_FOR_SLAVE_SELECT();
     // Send Command
     SpiDrv::sendCmd(GET_ANALOG_READ, PARAM_NUMS_1);
-    SpiDrv::sendParam((uint8_t*)&pin, 1, LAST_PARAM);
+    SpiDrv::sendParam((uint8_t*)&adc_channel, 1, LAST_PARAM);
 
     // pad to multiple of 4
     SpiDrv::readChar();

--- a/src/utility/wifi_drv.cpp
+++ b/src/utility/wifi_drv.cpp
@@ -1060,6 +1060,11 @@ void WiFiDrv::pinMode(uint8_t pin, uint8_t mode)
     SpiDrv::spiSlaveDeselect();
 }
 
+PinStatus WiFiDrv::digitalRead(uint8_t pin)
+{
+#warning "This needs to be implemented!!!"
+}
+
 void WiFiDrv::digitalWrite(uint8_t pin, uint8_t value)
 {
     WAIT_FOR_SLAVE_SELECT();
@@ -1085,6 +1090,11 @@ void WiFiDrv::digitalWrite(uint8_t pin, uint8_t value)
         _data = WL_FAILURE;
     }
     SpiDrv::spiSlaveDeselect();
+}
+
+int WiFiDrv::analogRead(uint8_t pin)
+{
+#warning "This needs to be implemented!!!"
 }
 
 void WiFiDrv::analogWrite(uint8_t pin, uint8_t value)

--- a/src/utility/wifi_drv.cpp
+++ b/src/utility/wifi_drv.cpp
@@ -1119,9 +1119,32 @@ void WiFiDrv::digitalWrite(uint8_t pin, uint8_t value)
     SpiDrv::spiSlaveDeselect();
 }
 
-int WiFiDrv::analogRead(uint8_t pin)
+uint16_t WiFiDrv::analogRead(uint8_t pin)
 {
-#warning "This needs to be implemented!!!"
+    WAIT_FOR_SLAVE_SELECT();
+    // Send Command
+    SpiDrv::sendCmd(GET_ANALOG_READ, PARAM_NUMS_1);
+    SpiDrv::sendParam((uint8_t*)&pin, 1, LAST_PARAM);
+
+    // pad to multiple of 4
+    SpiDrv::readChar();
+    SpiDrv::readChar();
+
+    SpiDrv::spiSlaveDeselect();
+    //Wait the reply elaboration
+    SpiDrv::waitForSlaveReady();
+    SpiDrv::spiSlaveSelect();
+
+    // Wait for reply
+    uint16_t adc_raw = 0;
+    uint8_t adc_raw_len = 0;
+    if (!SpiDrv::waitResponseCmd(GET_ANALOG_READ, PARAM_NUMS_1, (uint8_t*)&adc_raw, &adc_raw_len))
+    {
+        WARN("error waitResponse");
+    }
+    SpiDrv::spiSlaveDeselect();
+
+    return adc_raw;
 }
 
 void WiFiDrv::analogWrite(uint8_t pin, uint8_t value)

--- a/src/utility/wifi_drv.cpp
+++ b/src/utility/wifi_drv.cpp
@@ -1062,7 +1062,34 @@ void WiFiDrv::pinMode(uint8_t pin, uint8_t mode)
 
 PinStatus WiFiDrv::digitalRead(uint8_t pin)
 {
-#warning "This needs to be implemented!!!"
+    WAIT_FOR_SLAVE_SELECT();
+    // Send Command
+    SpiDrv::sendCmd(GET_DIGITAL_READ, PARAM_NUMS_1);
+    SpiDrv::sendParam((uint8_t*)&pin, 1, LAST_PARAM);
+
+    // pad to multiple of 4
+    SpiDrv::readChar();
+    SpiDrv::readChar();
+
+    SpiDrv::spiSlaveDeselect();
+    //Wait the reply elaboration
+    SpiDrv::waitForSlaveReady();
+    SpiDrv::spiSlaveSelect();
+
+    // Wait for reply
+    uint8_t _data = 0;
+    uint8_t _dataLen = 0;
+    if (!SpiDrv::waitResponseCmd(GET_DIGITAL_READ, PARAM_NUMS_1, &_data, &_dataLen))
+    {
+        WARN("error waitResponse");
+        _data = WL_FAILURE;
+    }
+    SpiDrv::spiSlaveDeselect();
+
+    if (_data == 1)
+        return HIGH;
+    else
+        return LOW;
 }
 
 void WiFiDrv::digitalWrite(uint8_t pin, uint8_t value)

--- a/src/utility/wifi_drv.h
+++ b/src/utility/wifi_drv.h
@@ -292,7 +292,7 @@ public:
     static void pinMode(uint8_t pin, uint8_t mode);
     static PinStatus digitalRead(uint8_t pin);
     static void digitalWrite(uint8_t pin, uint8_t value);
-    static uint16_t analogRead(uint8_t pin);
+    static uint16_t analogRead(uint8_t adc_channel);
     static void analogWrite(uint8_t pin, uint8_t value);
 
     static int8_t downloadFile(const char* url, uint8_t url_len, const char *filename, uint8_t filename_len);

--- a/src/utility/wifi_drv.h
+++ b/src/utility/wifi_drv.h
@@ -292,7 +292,7 @@ public:
     static void pinMode(uint8_t pin, uint8_t mode);
     static PinStatus digitalRead(uint8_t pin);
     static void digitalWrite(uint8_t pin, uint8_t value);
-    static int analogRead(uint8_t pin);
+    static uint16_t analogRead(uint8_t pin);
     static void analogWrite(uint8_t pin, uint8_t value);
 
     static int8_t downloadFile(const char* url, uint8_t url_len, const char *filename, uint8_t filename_len);

--- a/src/utility/wifi_drv.h
+++ b/src/utility/wifi_drv.h
@@ -290,7 +290,9 @@ public:
     static void debug(uint8_t on);
     static float getTemperature();
     static void pinMode(uint8_t pin, uint8_t mode);
+    static PinStatus digitalRead(uint8_t pin);
     static void digitalWrite(uint8_t pin, uint8_t value);
+    static int analogRead(uint8_t pin);
     static void analogWrite(uint8_t pin, uint8_t value);
 
     static int8_t downloadFile(const char* url, uint8_t url_len, const char *filename, uint8_t filename_len);

--- a/src/utility/wifi_spi.h
+++ b/src/utility/wifi_spi.h
@@ -103,6 +103,7 @@ enum {
     SET_DIGITAL_WRITE	= 0x51,
     SET_ANALOG_WRITE	= 0x52,
     GET_DIGITAL_READ    = 0x53,
+	GET_ANALOG_READ     = 0x54,
 
     // regular format commands
     WRITE_FILE			= 0x60,

--- a/src/utility/wifi_spi.h
+++ b/src/utility/wifi_spi.h
@@ -102,6 +102,7 @@ enum {
     SET_PIN_MODE		= 0x50,
     SET_DIGITAL_WRITE	= 0x51,
     SET_ANALOG_WRITE	= 0x52,
+    GET_DIGITAL_READ    = 0x53,
 
     // regular format commands
     WRITE_FILE			= 0x60,


### PR DESCRIPTION
For Arduino `Nano RP2040 Connect` which has those pins as well as the RGB LED directly connected to the NINA-W102.

Related: https://github.com/arduino/nina-fw/pull/64