### PR TITLE
Add Client.connectTimeout and Client.SSLConnectTimeout 

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -35,6 +35,7 @@ jobs:
           - fqbn: arduino:samd:mkrwifi1010
           - fqbn: arduino:samd:mkrvidor4000
           - fqbn: arduino:megaavr:uno2018:mode=on
+          - fqbn: arduino:mbed_nano:nanorp2040connect
 
     steps:
       - name: Checkout

--- a/keywords.txt
+++ b/keywords.txt
@@ -57,6 +57,8 @@ noLowPowerMode	KEYWORD2
 ping	KEYWORD2
 beginMulticast	KEYWORD2
 setTimeout	KEYWORD2
+setConnectTime	KEYWORD2
+setSSLConnectTime	KEYWORD2
 
 
 #######################################

--- a/keywords.txt
+++ b/keywords.txt
@@ -57,11 +57,10 @@ noLowPowerMode	KEYWORD2
 ping	KEYWORD2
 beginMulticast	KEYWORD2
 setTimeout	KEYWORD2
-setConnectTime	KEYWORD2
-setSSLConnectTime	KEYWORD2
+setConnectTimeout	KEYWORD2
+setSSLConnectTimeout	KEYWORD2
 
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=WiFiNINA
-version=1.8.6
+version=1.8.7
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables network connection (local and Internet) with the Arduino MKR WiFi 1010, Arduino MKR VIDOR 4000, Arduino UNO WiFi Rev.2 and Nano 33 IoT.

--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -122,7 +122,7 @@ int WiFiClient::connectSSL(const char *host, uint16_t port)
       unsigned long start = millis();
 
       // wait 4 second for the connection to close
-      while (!connected() && millis() - start < 10000)
+      while (!connected() && millis() - start < 5000)
         delay(1);
 
       if (!connected())

--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -35,10 +35,10 @@ extern "C" {
 
 uint16_t WiFiClient::_srcport = 1024;
 
-WiFiClient::WiFiClient() : _sock(NO_SOCKET_AVAIL), _retrySend(true) {
+WiFiClient::WiFiClient() : _sock(NO_SOCKET_AVAIL), _retrySend(true){
 }
 
-WiFiClient::WiFiClient(uint8_t sock) : _sock(sock), _retrySend(true) {
+WiFiClient::WiFiClient(uint8_t sock) : _sock(sock), _retrySend(true){
 }
 
 int WiFiClient::connect(const char* host, uint16_t port) {
@@ -64,7 +64,7 @@ int WiFiClient::connect(IPAddress ip, uint16_t port) {
     	unsigned long start = millis();
 
     	// wait 4 second for the connection to close
-    	while (!connected() && millis() - start < 2000)
+    	while (!connected() && millis() - start < _connectTime)
     		delay(1);
 
     	if (!connected())
@@ -93,7 +93,7 @@ int WiFiClient::connectSSL(IPAddress ip, uint16_t port)
       unsigned long start = millis();
 
       // wait 4 second for the connection to close
-      while (!connected() && millis() - start < 10000)
+      while (!connected() && millis() - start < _SSLConnectTime)
         delay(1);
 
       if (!connected())
@@ -122,7 +122,7 @@ int WiFiClient::connectSSL(const char *host, uint16_t port)
       unsigned long start = millis();
 
       // wait 4 second for the connection to close
-      while (!connected() && millis() - start < 5000)
+      while (!connected() && millis() - start < _SSLConnectTime)
         delay(1);
 
       if (!connected())
@@ -151,7 +151,7 @@ int WiFiClient::connectBearSSL(IPAddress ip, uint16_t port)
       unsigned long start = millis();
 
       // wait 4 second for the connection to close
-      while (!connected() && millis() - start < 10000)
+      while (!connected() && millis() - start < _SSLConnectTime)
         delay(1);
 
       if (!connected())
@@ -180,7 +180,7 @@ int WiFiClient::connectBearSSL(const char *host, uint16_t port)
       unsigned long start = millis();
 
       // wait 4 second for the connection to close
-      while (!connected() && millis() - start < 10000)
+      while (!connected() && millis() - start < _SSLConnectTime)
         delay(1);
 
       if (!connected())
@@ -285,6 +285,14 @@ int WiFiClient::peek() {
 
 void WiFiClient::setRetry(bool retry) {
   _retrySend = retry;
+}
+
+void WiFiClient::setConnectTime(uint16_t connectTime){
+  _connectTime = connectTime;
+}
+
+void WiFiClient::setSSLConnectTime(uint16_t SSLConnectTime){
+  _SSLConnectTime = SSLConnectTime;
 }
 
 void WiFiClient::flush() {

--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -64,7 +64,7 @@ int WiFiClient::connect(IPAddress ip, uint16_t port) {
     	unsigned long start = millis();
 
     	// wait 4 second for the connection to close
-    	while (!connected() && millis() - start < _connectTime)
+    	while (!connected() && millis() - start < _connectTimeout)
     		delay(1);
 
     	if (!connected())
@@ -93,7 +93,7 @@ int WiFiClient::connectSSL(IPAddress ip, uint16_t port)
       unsigned long start = millis();
 
       // wait 4 second for the connection to close
-      while (!connected() && millis() - start < _SSLConnectTime)
+      while (!connected() && millis() - start < _SSLConnectTimeout)
         delay(1);
 
       if (!connected())
@@ -122,7 +122,7 @@ int WiFiClient::connectSSL(const char *host, uint16_t port)
       unsigned long start = millis();
 
       // wait 4 second for the connection to close
-      while (!connected() && millis() - start < _SSLConnectTime)
+      while (!connected() && millis() - start < _SSLConnectTimeout)
         delay(1);
 
       if (!connected())
@@ -151,7 +151,7 @@ int WiFiClient::connectBearSSL(IPAddress ip, uint16_t port)
       unsigned long start = millis();
 
       // wait 4 second for the connection to close
-      while (!connected() && millis() - start < _SSLConnectTime)
+      while (!connected() && millis() - start < _SSLConnectTimeout)
         delay(1);
 
       if (!connected())
@@ -180,7 +180,7 @@ int WiFiClient::connectBearSSL(const char *host, uint16_t port)
       unsigned long start = millis();
 
       // wait 4 second for the connection to close
-      while (!connected() && millis() - start < _SSLConnectTime)
+      while (!connected() && millis() - start < _SSLConnectTimeout)
         delay(1);
 
       if (!connected())
@@ -257,7 +257,7 @@ int WiFiClient::available() {
   {
       return WiFiSocketBuffer.available(_sock);
   }
-   
+
   return 0;
 }
 
@@ -287,12 +287,12 @@ void WiFiClient::setRetry(bool retry) {
   _retrySend = retry;
 }
 
-void WiFiClient::setConnectTime(uint16_t connectTime){
-  _connectTime = connectTime;
+void WiFiClient::setConnectTime(uint16_t connectTimeout){
+  _connectTimeout = connectTimeout;
 }
 
-void WiFiClient::setSSLConnectTime(uint16_t SSLConnectTime){
-  _SSLConnectTime = SSLConnectTime;
+void WiFiClient::setSSLConnectTime(uint16_t SSLConnectTimeout){
+  _SSLConnectTimeout = SSLConnectTimeout;
 }
 
 void WiFiClient::flush() {

--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -64,7 +64,7 @@ int WiFiClient::connect(IPAddress ip, uint16_t port) {
     	unsigned long start = millis();
 
     	// wait 4 second for the connection to close
-    	while (!connected() && millis() - start < 10000)
+    	while (!connected() && millis() - start < 2000)
     		delay(1);
 
     	if (!connected())

--- a/src/WiFiClient.h
+++ b/src/WiFiClient.h
@@ -20,7 +20,7 @@
 
 #ifndef wificlient_h
 #define wificlient_h
-#include "Arduino.h"	
+#include "Arduino.h"
 #include "Print.h"
 #include "Client.h"
 #include "IPAddress.h"
@@ -66,8 +66,8 @@ private:
   uint8_t _sock;   //not used
   uint16_t  _socket;
   bool _retrySend;
-  uint16_t _connectTime = 10000;
-  uint16_t _SSLConnectTime = 10000;
+  uint16_t _connectTimeout = 10000;
+  uint16_t _SSLConnectTimeout = 10000;
 };
 
 #endif

--- a/src/WiFiClient.h
+++ b/src/WiFiClient.h
@@ -46,6 +46,8 @@ public:
   virtual int read(uint8_t *buf, size_t size);
   virtual int peek();
   virtual void setRetry(bool retry);
+  virtual void setConnectTime(uint16_t connectTime);
+  virtual void setSSLConnectTime(uint16_t SSLConnectTime);
   virtual void flush();
   virtual void stop();
   virtual uint8_t connected();
@@ -64,6 +66,8 @@ private:
   uint8_t _sock;   //not used
   uint16_t  _socket;
   bool _retrySend;
+  uint16_t _connectTime;
+  uint16_t _SSLConnectTime;
 };
 
 #endif

--- a/src/WiFiClient.h
+++ b/src/WiFiClient.h
@@ -66,8 +66,8 @@ private:
   uint8_t _sock;   //not used
   uint16_t  _socket;
   bool _retrySend;
-  uint16_t _connectTime;
-  uint16_t _SSLConnectTime;
+  uint16_t _connectTime = 10000;
+  uint16_t _SSLConnectTime = 10000;
 };
 
 #endif


### PR DESCRIPTION
to allow connect() to timeout faster than the hard coded 10,000msec, I made this because once in a while the Connection would trip my watchdog timer. Might be useful for anyone who is in a similiar situation or who may simply may not want to wait.