### PR TITLE
Provide clean API for passing watchdog function.

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -27,7 +27,7 @@ extern "C" {
   #include "utility/debug.h"
 }
 
-WiFiClass::WiFiClass() : _timeout(50000)
+WiFiClass::WiFiClass() : _timeout(50000), _feed_watchdog_func(0)
 {
 }
 
@@ -49,6 +49,7 @@ int WiFiClass::begin(const char* ssid)
    {
 	   for (unsigned long start = millis(); (millis() - start) < _timeout;)
 	   {
+		   feedWatchdog();
 		   delay(WL_DELAY_START_CONNECTION);
 		   status = WiFiDrv::getConnectionStatus();
 		   if ((status != WL_IDLE_STATUS) && (status != WL_NO_SSID_AVAIL) && (status != WL_SCAN_COMPLETED)) {
@@ -71,6 +72,7 @@ int WiFiClass::begin(const char* ssid, uint8_t key_idx, const char *key)
    {
 	   for (unsigned long start = millis(); (millis() - start) < _timeout;)
 	   {
+		   feedWatchdog();
 		   delay(WL_DELAY_START_CONNECTION);
 		   status = WiFiDrv::getConnectionStatus();
 		   if ((status != WL_IDLE_STATUS) && (status != WL_NO_SSID_AVAIL) && (status != WL_SCAN_COMPLETED)) {
@@ -92,6 +94,7 @@ int WiFiClass::begin(const char* ssid, const char *passphrase)
     {
 	   for (unsigned long start = millis(); (millis() - start) < _timeout;)
  	   {
+		   feedWatchdog();
  		   delay(WL_DELAY_START_CONNECTION);
  		   status = WiFiDrv::getConnectionStatus();
 		   if ((status != WL_IDLE_STATUS) && (status != WL_NO_SSID_AVAIL) && (status != WL_SCAN_COMPLETED)) {
@@ -382,4 +385,16 @@ void WiFiClass::setTimeout(unsigned long timeout)
 {
 	_timeout = timeout;
 }
+
+void WiFiClass::setFeedWatchdogFunc(FeedHostProcessorWatchdogFuncPointer func)
+{
+  _feed_watchdog_func = func;
+}
+
+void WiFiClass::feedWatchdog()
+{
+  if (_feed_watchdog_func)
+	_feed_watchdog_func();
+}
+
 WiFiClass WiFi;

--- a/src/WiFi.h
+++ b/src/WiFi.h
@@ -36,12 +36,15 @@ extern "C" {
 #include "WiFiServer.h"
 #include "WiFiStorage.h"
 
+typedef void(*FeedHostProcessorWatchdogFuncPointer)();
+
 class WiFiClass
 {
 private:
 
     static void init();
     unsigned long _timeout;
+    FeedHostProcessorWatchdogFuncPointer _feed_watchdog_func;
 public:
     WiFiClass();
 
@@ -274,6 +277,9 @@ public:
     int ping(IPAddress host, uint8_t ttl = 128);
 
     void setTimeout(unsigned long timeout);
+
+    void setFeedWatchdogFunc(FeedHostProcessorWatchdogFuncPointer func);
+    void feedWatchdog();
 };
 
 extern WiFiClass WiFi;

--- a/src/utility/spi_drv.cpp
+++ b/src/utility/spi_drv.cpp
@@ -22,6 +22,7 @@
 #include <SPI.h>
 #include "utility/spi_drv.h"
 #include "pins_arduino.h"
+#include "WiFi.h"
 
 #ifdef ARDUINO_SAMD_MKRVIDOR4000
 
@@ -67,13 +68,7 @@ static bool inverted_reset = false;
 
 bool SpiDrv::initialized = false;
 
-__attribute__((weak)) void wifi_nina_feed_watchdog()
-{
-    /* This function can be overwritten by a "strong" implementation
-     * in a higher level application, such as the ArduinoIoTCloud
-     * firmware stack.
-     */
-}
+extern WiFiClass WiFi;
 
 void SpiDrv::begin()
 {
@@ -227,7 +222,7 @@ void SpiDrv::waitForSlaveReady(bool const feed_watchdog)
     {
         if (feed_watchdog) {
             if ((millis() - start) < 10000) {
-                wifi_nina_feed_watchdog();
+                WiFi.feedWatchdog();
             }
         }
     }


### PR DESCRIPTION
Instead of relying on the 'hidden mechanism' of passing a function to feed the watchdog via a weak function definition pass a function pointer via a public API instead. This increases visibility and reduces unintentional introductions of bugs.