### PR TITLE
Replace hard-coded LED pin number with the portable LED_BUILTIN constant

### DIFF
--- a/examples/SimpleWebServerWiFi/SimpleWebServerWiFi.ino
+++ b/examples/SimpleWebServerWiFi/SimpleWebServerWiFi.ino
@@ -101,10 +101,10 @@ void loop() {
 
         // Check to see if the client request was "GET /H" or "GET /L":
         if (currentLine.endsWith("GET /H")) {
-          digitalWrite(9, HIGH);               // GET /H turns the LED on
+          digitalWrite(LED_BUILTIN, HIGH);               // GET /H turns the LED on
         }
         if (currentLine.endsWith("GET /L")) {
-          digitalWrite(9, LOW);                // GET /L turns the LED off
+          digitalWrite(LED_BUILTIN, LOW);                // GET /L turns the LED off
         }
       }
     }


### PR DESCRIPTION
This example contains a hard-coded pin number for the built-in LED, but this is not portable across all boards. This pull request replaces it with the safer `LED_BUILTIN` constant.