### PR TITLE
Increment WIFI_FIRMWARE_LATEST_VERSION to 1.4.7

### DIFF
--- a/src/WiFi.h
+++ b/src/WiFi.h
@@ -21,7 +21,7 @@
 #ifndef WiFi_h
 #define WiFi_h
 
-#define WIFI_FIRMWARE_LATEST_VERSION "1.4.6"
+#define WIFI_FIRMWARE_LATEST_VERSION "1.4.7"
 #define WIFI_HAS_FEED_WATCHDOG_FUNC
 
 #include <inttypes.h>


### PR DESCRIPTION
Due to the release of nina-fw:v1.4.7 (https://github.com/arduino/nina-fw/releases/tag/1.4.7) this version number needs to be incremented.