### PR TITLE
Watchdog trigger changes

### DIFF
--- a/src/utility/server_drv.cpp
+++ b/src/utility/server_drv.cpp
@@ -130,7 +130,7 @@ void ServerDrv::startClient(const char* host, uint8_t host_len, uint32_t ipAddre
 
     SpiDrv::spiSlaveDeselect();
     //Wait the reply elaboration
-    SpiDrv::waitForSlaveReady(/* feed_watchdog = */ (protMode == TLS_BEARSSL_MODE));
+    SpiDrv::waitForSlaveReady();
     SpiDrv::spiSlaveSelect();
 
     // Wait for reply

--- a/src/utility/spi_drv.cpp
+++ b/src/utility/spi_drv.cpp
@@ -224,6 +224,7 @@ void SpiDrv::waitForSlaveReady()
             WiFi.feedWatchdog();
             trigger_time = millis() + 10000;
         }
+        delay(10);
     }
 }
 

--- a/src/utility/spi_drv.cpp
+++ b/src/utility/spi_drv.cpp
@@ -215,16 +215,14 @@ void SpiDrv::waitForSlaveSign()
 	while (!waitSlaveSign());
 }
 
-void SpiDrv::waitForSlaveReady(bool const feed_watchdog)
+void SpiDrv::waitForSlaveReady()
 {
-    unsigned long trigger_time = millis() + 10000;
+    unsigned long trigger_time = millis();
 	while (!waitSlaveReady())
     {
-        if (feed_watchdog) {
-            if (static_cast<int32_t>(trigger_time - millis()) <=0) {
-                WiFi.feedWatchdog();
-                trigger_time = millis() + 10000;
-            }
+        if (static_cast<int32_t>(trigger_time - millis()) <=0) {
+            WiFi.feedWatchdog();
+            trigger_time = millis() + 10000;
         }
     }
 }

--- a/src/utility/spi_drv.cpp
+++ b/src/utility/spi_drv.cpp
@@ -217,12 +217,13 @@ void SpiDrv::waitForSlaveSign()
 
 void SpiDrv::waitForSlaveReady(bool const feed_watchdog)
 {
-    unsigned long const start = millis();
+    unsigned long trigger_time = millis() + 10000;
 	while (!waitSlaveReady())
     {
         if (feed_watchdog) {
-            if ((millis() - start) < 10000) {
+            if (static_cast<int32_t>(trigger_time - millis()) <=0) {
                 WiFi.feedWatchdog();
+                trigger_time = millis() + 10000;
             }
         }
     }

--- a/src/utility/spi_drv.h
+++ b/src/utility/spi_drv.h
@@ -59,7 +59,7 @@ public:
     
     static char spiTransfer(volatile char data);
 
-    static void waitForSlaveReady(bool const feed_watchdog = false);
+    static void waitForSlaveReady();
 
     //static int waitSpiChar(char waitChar, char* readChar);
 


### PR DESCRIPTION
I'm opening this PR to have a bit of discussion since i'm not 100% sure of the changes:

- https://github.com/arduino-libraries/WiFiNINA/commit/162049aef9b4ef2fc92504753bc8c9da166cbbab with the original code the wdog is triggered continously for 10 seconds without delays. Considering a wdog window of 32 seconds i've changed the code in order to kik the wdog each 10 seconds .

 - https://github.com/arduino-libraries/WiFiNINA/commit/a37d3500724d0f1ff59756bd8c481ded9d41d240 since the wdog is triggered only if the callback is configured i think we can safely remove the check on `feed_watchdog` and always trigger the wdog if the callback is correctly configured in the library. This change will also extend the wdog trigger to all `SpiDrv::waitForSlaveReady()` calls. I have not experienced any drawback doing this, but propably is too much... if we want to drop this change we need to extend the wdog trig at least to `ServerDrv::getClientState ` since i've seen some wdog resets also in this function.
 
  - https://github.com/arduino-libraries/WiFiNINA/commit/51590dbc0dcfdc578e119397943e940e40fab4b4 I don't have an explanation for this, but i've noticed that without this delay sometimes the board gets stuck in this while loop, maybe is related to the fact `digitalRead` is not a real digital read, but is implemented as spi command...