### PR TITLE
Replace unicode left/right quotes with normal quotes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -593,7 +593,7 @@ WiFi.setHostname(hostname)
 
 ```
 …
-  WiFi.setHostname(“MyArduino”);
+  WiFi.setHostname("MyArduino");
 
   // attempt to connect to Wifi network:
   while (status != WL_CONNECTED) {
@@ -2788,7 +2788,7 @@ server.status()
 ```
 …
 
-Serial.print(“connection status: ”);
+Serial.print("connection status: ");
 Serial.println(client.status());
 
 …


### PR DESCRIPTION
Replace double turned comma quotes (U+201C, U+201D) with programmer's double quotes (U+0022).

Some of the example code snippets use unicode fancy quotes instead of normal plain double quotes. This throws a compile error if the examples are copy/pasted into sketches.