### PR TITLE
stop checking disconnected _lastSock

### DIFF
--- a/src/WiFiServer.cpp
+++ b/src/WiFiServer.cpp
@@ -62,7 +62,9 @@ WiFiClient WiFiServer::available(byte* status)
       if (sock == NO_SOCKET_AVAIL) {
           // check for new client socket
           sock = ServerDrv::availServer(_sock);
-      }
+      } else {
+          _lastSock = NO_SOCKET_AVAIL;
+      }    
     }
 
     if (sock != NO_SOCKET_AVAIL) {


### PR DESCRIPTION
WiFiServer was checking _lastSock forever. It slowed down the sketch.
This PR sets _lastSock to NO_SOCKET_AVAIL if firmware reports the 'sock' as disconnected.

EDIT: In a sketch with other TCP connections (client connections, other server) the 'sock' stored in _lastSock maybe reused and then without this fix, the server would return some unrelated client connection. It still can happen if the 'sock' is reused before this fix detects that it was disconnected