### PR TITLE
WiFiClient connect timeout

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2638,6 +2638,72 @@ client.remotePort()
 #### Returns
 The port of the remote host that the client is connected to
 
+### `client.setConnectionTimeout()`
+
+#### Description
+
+Set the timeout for client.connect(). With timeout value not set, a connect attempt times out after the time determined by the firmware which is more than 18 seconds. You might prefer to set a lower timeout value to make your program more responsive in the event something goes wrong.
+
+
+#### Syntax
+
+```
+client.setConnectionTimeout(milliseconds)
+
+```
+
+#### Parameters
+- milliseconds: the timeout duration for client.connect() (uint16_t)
+
+#### Returns
+Nothing
+
+#### Example
+
+```
+#include <WiFiNINA.h>
+
+#include "arduino_secrets.h"
+char ssid[] = SECRET_SSID;
+char pass[] = SECRET_PASS;
+
+IPAddress server(192,168,0,177);
+WiFiClient client;
+
+void setup() {
+
+  Serial.begin(115200);
+  while (!Serial) {}
+
+  Serial.print("Attempting to connect to SSID: ");
+  Serial.println(ssid);
+  int status = WiFi.begin(ssid, pass);
+  if ( status != WL_CONNECTED) {
+    Serial.println("Couldn't get a WiFi connection");
+    while(true);
+  }
+
+  client.setConnectionTimeout(3000); // 3 seconds
+
+  Serial.println("\nStarting connection to server...");
+  unsigned long startTime = millis();
+  if (client.connect(server, 80)) {
+    client.println("Connected");
+  } else {
+    client.println("Not Connected");
+  }
+
+  Serial.print("connect time (milliseconds): ");
+  Serial.println(millis()- startTime);
+
+  client.stop();
+}
+
+void loop() {
+}
+
+```
+
 ## Server Class
 
 ### `Server()`

--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -59,13 +59,7 @@ int WiFiClient::connect(IPAddress ip, uint16_t port) {
     _sock = ServerDrv::getSocket();
     if (_sock != NO_SOCKET_AVAIL)
     {
-    	ServerDrv::startClient(uint32_t(ip), port, _sock);
-
-    	unsigned long start = millis();
-
-    	// wait 4 second for the connection to close
-    	while (!connected() && millis() - start < 10000)
-    		delay(1);
+    	ServerDrv::startClient(nullptr, 0, uint32_t(ip), port, _sock, TCP_MODE, _connTimeout);
 
     	if (!connected())
        	{
@@ -88,13 +82,7 @@ int WiFiClient::connectSSL(IPAddress ip, uint16_t port)
     _sock = ServerDrv::getSocket();
     if (_sock != NO_SOCKET_AVAIL)
     {
-      ServerDrv::startClient(uint32_t(ip), port, _sock, TLS_MODE);
-
-      unsigned long start = millis();
-
-      // wait 4 second for the connection to close
-      while (!connected() && millis() - start < 10000)
-        delay(1);
+      ServerDrv::startClient(nullptr, 0, uint32_t(ip), port, _sock, TLS_MODE, _connTimeout);
 
       if (!connected())
         {
@@ -117,13 +105,7 @@ int WiFiClient::connectSSL(const char *host, uint16_t port)
     _sock = ServerDrv::getSocket();
     if (_sock != NO_SOCKET_AVAIL)
     {
-      ServerDrv::startClient(host, strlen(host), uint32_t(0), port, _sock, TLS_MODE);
-
-      unsigned long start = millis();
-
-      // wait 4 second for the connection to close
-      while (!connected() && millis() - start < 10000)
-        delay(1);
+      ServerDrv::startClient(host, strlen(host), uint32_t(0), port, _sock, TLS_MODE, _connTimeout);
 
       if (!connected())
         {
@@ -146,13 +128,7 @@ int WiFiClient::connectBearSSL(IPAddress ip, uint16_t port)
     _sock = ServerDrv::getSocket();
     if (_sock != NO_SOCKET_AVAIL)
     {
-      ServerDrv::startClient(uint32_t(ip), port, _sock, TLS_BEARSSL_MODE);
-
-      unsigned long start = millis();
-
-      // wait 4 second for the connection to close
-      while (!connected() && millis() - start < 10000)
-        delay(1);
+      ServerDrv::startClient(nullptr, 0, uint32_t(ip), port, _sock, TLS_BEARSSL_MODE, _connTimeout);
 
       if (!connected())
         {
@@ -175,13 +151,7 @@ int WiFiClient::connectBearSSL(const char *host, uint16_t port)
     _sock = ServerDrv::getSocket();
     if (_sock != NO_SOCKET_AVAIL)
     {
-      ServerDrv::startClient(host, strlen(host), uint32_t(0), port, _sock, TLS_BEARSSL_MODE);
-
-      unsigned long start = millis();
-
-      // wait 4 second for the connection to close
-      while (!connected() && millis() - start < 10000)
-        delay(1);
+      ServerDrv::startClient(host, strlen(host), uint32_t(0), port, _sock, TLS_BEARSSL_MODE, _connTimeout);
 
       if (!connected())
         {

--- a/src/WiFiClient.h
+++ b/src/WiFiClient.h
@@ -32,6 +32,8 @@ public:
   WiFiClient(uint8_t sock);
 
   uint8_t status();
+  void setConnectionTimeout(uint16_t timeout) {_connTimeout = timeout;}
+
   virtual int connect(IPAddress ip, uint16_t port);
   virtual int connect(const char *host, uint16_t port);
   virtual int connectSSL(IPAddress ip, uint16_t port);
@@ -61,8 +63,8 @@ public:
 
 private:
   static uint16_t _srcport;
-  uint8_t _sock;   //not used
-  uint16_t  _socket;
+  uint8_t _sock;
+  uint16_t  _connTimeout = 0;
   bool _retrySend;
 };
 

--- a/src/utility/server_drv.cpp
+++ b/src/utility/server_drv.cpp
@@ -110,19 +110,20 @@ void ServerDrv::startClient(uint32_t ipAddress, uint16_t port, uint8_t sock, uin
     SpiDrv::spiSlaveDeselect();
 }
 
-void ServerDrv::startClient(const char* host, uint8_t host_len, uint32_t ipAddress, uint16_t port, uint8_t sock, uint8_t protMode)
+void ServerDrv::startClient(const char* host, uint8_t host_len, uint32_t ipAddress, uint16_t port, uint8_t sock, uint8_t protMode, uint16_t timeout)
 {
     WAIT_FOR_SLAVE_SELECT();
     // Send Command
-    SpiDrv::sendCmd(START_CLIENT_TCP_CMD, PARAM_NUMS_5);
+    SpiDrv::sendCmd(START_CLIENT_TCP_CMD, PARAM_NUMS_6);
     SpiDrv::sendParam((uint8_t*)host, host_len);
     SpiDrv::sendParam((uint8_t*)&ipAddress, sizeof(ipAddress));
     SpiDrv::sendParam(port);
     SpiDrv::sendParam(&sock, 1);
-    SpiDrv::sendParam(&protMode, 1, LAST_PARAM);
+    SpiDrv::sendParam(&protMode, 1);
+    SpiDrv::sendParam(timeout, LAST_PARAM);
 
     // pad to multiple of 4
-    int commandSize = 17 + host_len;
+    int commandSize = 20 + host_len;
     while (commandSize % 4) {
         SpiDrv::readChar();
         commandSize++;

--- a/src/utility/server_drv.h
+++ b/src/utility/server_drv.h
@@ -37,7 +37,7 @@ public:
 
     static void startClient(uint32_t ipAddress, uint16_t port, uint8_t sock, uint8_t protMode=TCP_MODE);
 
-    static void startClient(const char* host, uint8_t host_len, uint32_t ipAddress, uint16_t port, uint8_t sock, uint8_t protMode=TCP_MODE);
+    static void startClient(const char* host, uint8_t host_len, uint32_t ipAddress, uint16_t port, uint8_t sock, uint8_t protMode=TCP_MODE, uint16_t timeout = 0);
 
     static void stopClient(uint8_t sock);
                                                                                   


### PR DESCRIPTION
Following the support in the firmware in https://github.com/arduino/nina-fw/pull/89, here is the implementation of WiFiClient.connect timeout.

Additionally the strange 10 seconds waiting time is removed.

overview of Client API in Arduino networking libraries:
https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#client-getters-and-setters

