### PR TITLE
Explicit use of includes from ArduinoCore-API

### DIFF
--- a/src/WiFi.h
+++ b/src/WiFi.h
@@ -31,7 +31,7 @@ extern "C" {
 	#include "utility/wl_types.h"
 }
 
-#include "IPAddress.h"
+#include "api/IPAddress.h"
 #include "WiFiClient.h"
 #include "WiFiSSLClient.h"
 #include "WiFiServer.h"

--- a/src/WiFiClient.h
+++ b/src/WiFiClient.h
@@ -21,9 +21,9 @@
 #ifndef wificlient_h
 #define wificlient_h
 #include "Arduino.h"	
-#include "Print.h"
-#include "Client.h"
-#include "IPAddress.h"
+#include "api/Print.h"
+#include "api/Client.h"
+#include "api/IPAddress.h"
 
 class WiFiClient : public Client {
 

--- a/src/WiFiServer.h
+++ b/src/WiFiServer.h
@@ -25,7 +25,7 @@ extern "C" {
   #include "utility/wl_definitions.h"
 }
 
-#include "Server.h"
+#include "api/Server.h"
 
 class WiFiClient;
 

--- a/src/WiFiUdp.h
+++ b/src/WiFiUdp.h
@@ -21,7 +21,7 @@
 #ifndef wifiudp_h
 #define wifiudp_h
 
-#include <Udp.h>
+#include <api/Udp.h>
 
 #define UDP_TX_PACKET_MAX_SIZE 24
 

--- a/src/utility/wifi_drv.h
+++ b/src/utility/wifi_drv.h
@@ -23,7 +23,7 @@
 
 #include <inttypes.h>
 #include "utility/wifi_spi.h"
-#include "IPAddress.h"
+#include "api/IPAddress.h"
 #include "WiFiUdp.h"
 #include "WiFiClient.h"
 


### PR DESCRIPTION
Those files:
- `IPAddress.h`
- `Print.h`
- `Client.h`
- `Server.h`
- `Udp.h`

are located under the `api` directory of `ArduinoCore-API` repository https://github.com/arduino/ArduinoCore-API
Those same files are also located in the `ArduinoCore-samd` repository https://github.com/arduino/ArduinoCore-samd
and conflicting.

When compiling for SAMD21, files from `ArduinoCore-samd` are used as the `api` directory is not specified while files from the `ArduinoCore-API` should be used.
The result is a conflict of declarations (`class UDP` being declared twice for example) and compilation fails.

So, this merge request explicit the `api` directory to avoid confusion and use `ArduinoCore-API`.