### PR TITLE
Fix sockets not closing properly by connected()

### DIFF
--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -302,8 +302,7 @@ uint8_t WiFiClient::connected() {
                       (s == CLOSE_WAIT));
 
     if (result == 0) {
-      WiFiSocketBuffer.close(_sock);
-      _sock = 255;
+      stop();
     }
 
     return result;


### PR DESCRIPTION
When checking `client.connected()` it would set `_sock` to `255` internally, but won't actually communicate back to NINA that the fd is closed so it won't be able to be reused.

See also: https://github.com/adafruit/WiFiNINA/pull/18